### PR TITLE
[Config] Fix relative Xcode paths

### DIFF
--- a/iOS/Compiler Explorer.xcodeproj/project.pbxproj
+++ b/iOS/Compiler Explorer.xcodeproj/project.pbxproj
@@ -225,7 +225,7 @@
 				8292AD1222ECB61500B1A165 /* Info.plist */,
 			);
 			name = GodBolt;
-			path = "../../../../../../../../../Users/cfi/Desktop/Compiler Explorer/GodBolt";
+			path = ../GodBolt;
 			sourceTree = "<group>";
 		};
 		8292AD1B22ECB62400B1A165 /* SavannaKit */ = {
@@ -240,7 +240,7 @@
 				8292AD3122ECB62400B1A165 /* Info.plist */,
 			);
 			name = SavannaKit;
-			path = "../../../../../../../../../Users/cfi/Desktop/Compiler Explorer/SavannaKit";
+			path = ../SavannaKit;
 			sourceTree = "<group>";
 		};
 		8292AD1C22ECB62400B1A165 /* Util */ = {


### PR DESCRIPTION
A bug in Xcode 11 Beta 5 caused files to be imported relative to root, resulting in the file locations being invalid for other users/machines. 